### PR TITLE
Ability to add example values to parameters ('x-example' property)

### DIFF
--- a/fixtures/features/api-elements/x-example-and-request-body.json
+++ b/fixtures/features/api-elements/x-example-and-request-body.json
@@ -1,0 +1,114 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "Parameters"
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "href": "/test"
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "POST"
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBodySchema"
+                            ]
+                          },
+                          "attributes": {
+                            "contentType": "application/schema+json"
+                          },
+                          "content": "{\"type\":\"string\"}"
+                        }
+                      ]
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "statusCode": "200"
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "meta": {},
+                          "attributes": {},
+                          "content": "Test description"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "error"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                260,
+                22
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "The 'x-example' property isn't allowed for body parameters - use 'schema.example' instead"
+    }
+  ]
+}

--- a/fixtures/features/api-elements/x-example-and-request-body.sourcemap.json
+++ b/fixtures/features/api-elements/x-example-and-request-body.sourcemap.json
@@ -1,0 +1,217 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": {
+          "element": "string",
+          "meta": {},
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    23,
+                    17
+                  ]
+                ]
+              }
+            ]
+          },
+          "content": "Parameters"
+        }
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "href": {
+              "element": "string",
+              "meta": {},
+              "attributes": {
+                "sourceMap": [
+                  {
+                    "element": "sourceMap",
+                    "meta": {},
+                    "attributes": {},
+                    "content": [
+                      [
+                        67,
+                        286
+                      ]
+                    ]
+                  }
+                ]
+              },
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    80,
+                                    273
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "POST"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBodySchema"
+                            ]
+                          },
+                          "attributes": {
+                            "contentType": "application/schema+json",
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    217,
+                                    43
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "{\"type\":\"string\"}"
+                        }
+                      ]
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    308,
+                                    45
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "meta": {},
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    323,
+                                    29
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "Test description"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "error"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                260,
+                22
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "The 'x-example' property isn't allowed for body parameters - use 'schema.example' instead"
+    }
+  ]
+}

--- a/fixtures/features/api-elements/x-example.json
+++ b/fixtures/features/api-elements/x-example.json
@@ -1,0 +1,278 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "Form Test"
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {},
+                  "attributes": {
+                    "typeAttributes": [
+                      "required"
+                    ]
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": "param"
+                    },
+                    "value": {
+                      "element": "number",
+                      "meta": {},
+                      "attributes": {},
+                      "content": 42
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {},
+                  "attributes": {},
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": "order"
+                    },
+                    "value": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {
+                        "default": "desc"
+                      },
+                      "content": "asc"
+                    }
+                  }
+                }
+              ]
+            },
+            "href": "/test/{param}{?order}"
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "GET",
+                        "headers": {
+                          "element": "httpHeaders",
+                          "meta": {},
+                          "attributes": {},
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {},
+                              "attributes": {},
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "user-agent"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "Examplebot/4.2 (+http://www.example.com/bot.html)"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "links": [
+                                  {
+                                    "element": "link",
+                                    "meta": {},
+                                    "attributes": {
+                                      "relation": "inferred",
+                                      "href": "http://docs.apiary.io/validations/swagger#form-data-content-type"
+                                    },
+                                    "content": []
+                                  }
+                                ]
+                              },
+                              "attributes": {},
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "application/x-www-form-urlencoded"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBody"
+                            ],
+                            "links": [
+                              {
+                                "element": "link",
+                                "meta": {},
+                                "attributes": {
+                                  "relation": "inferred",
+                                  "href": "http://docs.apiary.io/validations/swagger#message-body-generation"
+                                },
+                                "content": []
+                              }
+                            ]
+                          },
+                          "attributes": {
+                            "contentType": "application/x-www-form-urlencoded"
+                          },
+                          "content": "id=false&greeting=hello"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "meta": {},
+                          "attributes": {},
+                          "content": {
+                            "element": "object",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              {
+                                "element": "member",
+                                "meta": {},
+                                "attributes": {
+                                  "typeAttributes": [
+                                    "required"
+                                  ]
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": "id"
+                                  },
+                                  "value": {
+                                    "element": "boolean",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": false
+                                  }
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "meta": {},
+                                "attributes": {
+                                  "typeAttributes": [
+                                    "required"
+                                  ]
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": "greeting"
+                                  },
+                                  "value": {
+                                    "element": "enum",
+                                    "meta": {},
+                                    "attributes": {
+                                      "default": [
+                                        "good morning"
+                                      ]
+                                    },
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "meta": {},
+                                        "attributes": {},
+                                        "content": "hi"
+                                      },
+                                      {
+                                        "element": "string",
+                                        "meta": {},
+                                        "attributes": {},
+                                        "content": "good morning"
+                                      },
+                                      {
+                                        "element": "string",
+                                        "meta": {},
+                                        "attributes": {},
+                                        "content": "hello"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "statusCode": "200"
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "meta": {},
+                          "attributes": {},
+                          "content": "Success"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/features/api-elements/x-example.sourcemap.json
+++ b/fixtures/features/api-elements/x-example.sourcemap.json
@@ -36,6 +36,130 @@
           "element": "resource",
           "meta": {},
           "attributes": {
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            109,
+                            101
+                          ]
+                        ]
+                      }
+                    ],
+                    "typeAttributes": [
+                      "required"
+                    ]
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": "param"
+                    },
+                    "value": {
+                      "element": "number",
+                      "meta": {},
+                      "attributes": {
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                109,
+                                101
+                              ]
+                            ]
+                          }
+                        ]
+                      },
+                      "content": 42
+                    }
+                  }
+                },
+                {
+                  "element": "member",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            212,
+                            100
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": "order"
+                    },
+                    "value": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {
+                        "default": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    294,
+                                    13
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "desc"
+                        },
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                212,
+                                100
+                              ]
+                            ]
+                          }
+                        ]
+                      },
+                      "content": "asc"
+                    }
+                  }
+                }
+              ]
+            },
             "href": {
               "element": "string",
               "meta": {},
@@ -48,13 +172,13 @@
                     "content": [
                       [
                         68,
-                        491
+                        850
                       ]
                     ]
                   }
                 ]
               },
-              "content": "/test"
+              "content": "/test/{param}{?order}"
             }
           },
           "content": [
@@ -83,8 +207,8 @@
                                 "attributes": {},
                                 "content": [
                                   [
-                                    216,
-                                    343
+                                    312,
+                                    606
                                   ]
                                 ]
                               }
@@ -97,6 +221,39 @@
                           "meta": {},
                           "attributes": {},
                           "content": [
+                            {
+                              "element": "member",
+                              "meta": {},
+                              "attributes": {
+                                "sourceMap": [
+                                  {
+                                    "element": "sourceMap",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": [
+                                      [
+                                        698,
+                                        163
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "user-agent"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "Examplebot/4.2 (+http://www.example.com/bot.html)"
+                                }
+                              }
+                            },
                             {
                               "element": "member",
                               "meta": {
@@ -153,7 +310,7 @@
                           "attributes": {
                             "contentType": "application/x-www-form-urlencoded"
                           },
-                          "content": "id=1&bar=chocolate-bar"
+                          "content": "id=false&greeting=hello"
                         },
                         {
                           "element": "dataStructure",
@@ -175,8 +332,8 @@
                                       "attributes": {},
                                       "content": [
                                         [
-                                          249,
-                                          120
+                                          345,
+                                          116
                                         ]
                                       ]
                                     }
@@ -193,7 +350,7 @@
                                     "content": "id"
                                   },
                                   "value": {
-                                    "element": "enum",
+                                    "element": "boolean",
                                     "meta": {},
                                     "attributes": {
                                       "sourceMap": [
@@ -203,35 +360,14 @@
                                           "attributes": {},
                                           "content": [
                                             [
-                                              249,
-                                              120
+                                              345,
+                                              116
                                             ]
                                           ]
                                         }
                                       ]
                                     },
-                                    "content": [
-                                      {
-                                        "element": "number",
-                                        "meta": {},
-                                        "attributes": {
-                                          "sourceMap": [
-                                            {
-                                              "element": "sourceMap",
-                                              "meta": {},
-                                              "attributes": {},
-                                              "content": [
-                                                [
-                                                  334,
-                                                  1
-                                                ]
-                                              ]
-                                            }
-                                          ]
-                                        },
-                                        "content": 1
-                                      }
-                                    ]
+                                    "content": false
                                   }
                                 }
                               },
@@ -246,8 +382,8 @@
                                       "attributes": {},
                                       "content": [
                                         [
-                                          371,
-                                          131
+                                          463,
+                                          233
                                         ]
                                       ]
                                     }
@@ -261,12 +397,34 @@
                                     "element": "string",
                                     "meta": {},
                                     "attributes": {},
-                                    "content": "bar"
+                                    "content": "greeting"
                                   },
                                   "value": {
                                     "element": "enum",
                                     "meta": {},
                                     "attributes": {
+                                      "default": [
+                                        {
+                                          "element": "string",
+                                          "meta": {},
+                                          "attributes": {
+                                            "sourceMap": [
+                                              {
+                                                "element": "sourceMap",
+                                                "meta": {},
+                                                "attributes": {},
+                                                "content": [
+                                                  [
+                                                    666,
+                                                    21
+                                                  ]
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "content": "good morning"
+                                        }
+                                      ],
                                       "sourceMap": [
                                         {
                                           "element": "sourceMap",
@@ -274,8 +432,8 @@
                                           "attributes": {},
                                           "content": [
                                             [
-                                              371,
-                                              131
+                                              463,
+                                              233
                                             ]
                                           ]
                                         }
@@ -293,14 +451,54 @@
                                               "attributes": {},
                                               "content": [
                                                 [
-                                                  457,
-                                                  13
+                                                  554,
+                                                  2
                                                 ]
                                               ]
                                             }
                                           ]
                                         },
-                                        "content": "chocolate-bar"
+                                        "content": "hi"
+                                      },
+                                      {
+                                        "element": "string",
+                                        "meta": {},
+                                        "attributes": {
+                                          "sourceMap": [
+                                            {
+                                              "element": "sourceMap",
+                                              "meta": {},
+                                              "attributes": {},
+                                              "content": [
+                                                [
+                                                  571,
+                                                  12
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "content": "good morning"
+                                      },
+                                      {
+                                        "element": "string",
+                                        "meta": {},
+                                        "attributes": {
+                                          "sourceMap": [
+                                            {
+                                              "element": "sourceMap",
+                                              "meta": {},
+                                              "attributes": {},
+                                              "content": [
+                                                [
+                                                  598,
+                                                  5
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "content": "hello"
                                       }
                                     ]
                                   }
@@ -326,7 +524,7 @@
                                 "attributes": {},
                                 "content": [
                                   [
-                                    521,
+                                    880,
                                     38
                                   ]
                                 ]
@@ -348,7 +546,7 @@
                                 "attributes": {},
                                 "content": [
                                   [
-                                    536,
+                                    895,
                                     22
                                   ]
                                 ]
@@ -366,78 +564,6 @@
           ]
         }
       ]
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": [
-          "warning"
-        ],
-        "links": [
-          {
-            "element": "link",
-            "meta": {},
-            "attributes": {
-              "relation": "origin",
-              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
-            },
-            "content": []
-          }
-        ]
-      },
-      "attributes": {
-        "code": 3,
-        "sourceMap": [
-          {
-            "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
-            "content": [
-              [
-                101,
-                57
-              ]
-            ]
-          }
-        ]
-      },
-      "content": "Path-level form data parameters are not yet supported"
-    },
-    {
-      "element": "annotation",
-      "meta": {
-        "classes": [
-          "warning"
-        ],
-        "links": [
-          {
-            "element": "link",
-            "meta": {},
-            "attributes": {
-              "relation": "origin",
-              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
-            },
-            "content": []
-          }
-        ]
-      },
-      "attributes": {
-        "code": 3,
-        "sourceMap": [
-          {
-            "element": "sourceMap",
-            "meta": {},
-            "attributes": {},
-            "content": [
-              [
-                160,
-                56
-              ]
-            ]
-          }
-        ]
-      },
-      "content": "Path-level form data parameters are not yet supported"
     }
   ]
 }

--- a/fixtures/features/swagger/x-example-and-request-body.yaml
+++ b/fixtures/features/swagger/x-example-and-request-body.yaml
@@ -1,0 +1,18 @@
+swagger: '2.0'
+info:
+  title: Parameters
+  version: '1.0'
+paths:
+  '/test':
+    post:
+      parameters:
+        - name: title
+          in: body
+          description: Body argument
+          required: true
+          schema:
+            type: string
+          x-example: Hello World
+      responses:
+        200:
+          description: Test description

--- a/fixtures/features/swagger/x-example.yaml
+++ b/fixtures/features/swagger/x-example.yaml
@@ -1,0 +1,42 @@
+swagger: '2.0'
+info:
+  title: 'Form Test'
+  version: '1.0'
+paths:
+  '/test/{param}':
+    parameters:
+      - name: param
+        in: path
+        type: number
+        required: true
+        x-example: 42
+      - name: order
+        in: query
+        type: string
+        x-example: asc
+        default: desc
+    get:
+      parameters:
+        - name: id
+          in: formData
+          type: boolean
+          required: true
+          x-example: false
+        - name: greeting
+          in: formData
+          type: string
+          enum:
+            - hi
+            - good morning
+            - hello
+          required: true
+          x-example: hello
+          default: good morning
+        - name: user-agent
+          in: header
+          type: string
+          required: true
+          x-example: Examplebot/4.2 (+http://www.example.com/bot.html)
+      responses:
+        200:
+          description: 'Success'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Swagger example files for testing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixtures added in this PR represent the correct behavior of the Fury Swagger Adapter if it meets a parameter property called `x-example`. The intended behavior is to:
- Add example value for  `header`, `formData`, `path`, and `query` parameters.
- Ignore `x-example` within `body` parameters and warn that `schema.example` should be used instead.
- The example value should get priority over the `default` value.
- The example value should get priority over the first of `enum` values. (In that case, it should be one of the specified values though).

---

This PR is a part of https://github.com/apiaryio/dredd/issues/561 implementation.
