### PR TITLE
Sample values should be generated as 'samples' in enums

### DIFF
--- a/fixtures/features/api-elements/x-example.json
+++ b/fixtures/features/api-elements/x-example.json
@@ -219,6 +219,11 @@
                                     "element": "enum",
                                     "meta": {},
                                     "attributes": {
+                                      "samples": [
+                                        [
+                                          "hello"
+                                        ]
+                                      ],
                                       "default": [
                                         "good morning"
                                       ]

--- a/fixtures/features/api-elements/x-example.sourcemap.json
+++ b/fixtures/features/api-elements/x-example.sourcemap.json
@@ -403,6 +403,11 @@
                                     "element": "enum",
                                     "meta": {},
                                     "attributes": {
+                                      "samples": [
+                                        [
+                                          "hello"
+                                        ]
+                                      ],
                                       "default": [
                                         {
                                           "element": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Swagger example files for testing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Aligning the behavior with what similar API Blueprint document would produce.
