### PR TITLE
Fix missing multipart end line

### DIFF
--- a/fixtures/features/api-elements/consumes-multipart-form-with-boundary.json
+++ b/fixtures/features/api-elements/consumes-multipart-form-with-boundary.json
@@ -120,7 +120,7 @@
                               "content": "multipart/form-data; boundary=hello"
                             }
                           },
-                          "content": "--hello\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\ndoe--hello\r\nContent-Disposition: form-data; name=\"id\"\r\n\r\n1"
+                          "content": "--hello\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\ndoe\r\n--hello\r\nContent-Disposition: form-data; name=\"id\"\r\n\r\n1\r\n\r\n--hello--\r\n"
                         },
                         {
                           "element": "dataStructure",

--- a/fixtures/features/api-elements/consumes-multipart-form-with-boundary.sourcemap.json
+++ b/fixtures/features/api-elements/consumes-multipart-form-with-boundary.sourcemap.json
@@ -195,7 +195,7 @@
                               "content": "multipart/form-data; boundary=hello"
                             }
                           },
-                          "content": "--hello\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\ndoe--hello\r\nContent-Disposition: form-data; name=\"id\"\r\n\r\n1"
+                          "content": "--hello\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\ndoe\r\n--hello\r\nContent-Disposition: form-data; name=\"id\"\r\n\r\n1\r\n\r\n--hello--\r\n"
                         },
                         {
                           "element": "dataStructure",

--- a/fixtures/features/api-elements/consumes-multipart-form.json
+++ b/fixtures/features/api-elements/consumes-multipart-form.json
@@ -120,7 +120,7 @@
                               "content": "multipart/form-data; boundary=BOUNDARY"
                             }
                           },
-                          "content": "--BOUNDARY\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nDoe"
+                          "content": "--BOUNDARY\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nDoe\r\n\r\n--BOUNDARY--\r\n"
                         },
                         {
                           "element": "dataStructure",

--- a/fixtures/features/api-elements/consumes-multipart-form.sourcemap.json
+++ b/fixtures/features/api-elements/consumes-multipart-form.sourcemap.json
@@ -195,7 +195,7 @@
                               "content": "multipart/form-data; boundary=BOUNDARY"
                             }
                           },
-                          "content": "--BOUNDARY\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nDoe"
+                          "content": "--BOUNDARY\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nDoe\r\n\r\n--BOUNDARY--\r\n"
                         },
                         {
                           "element": "dataStructure",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Swagger example files for testing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
From the [rfc1341](https://tools.ietf.org/html/rfc1341):

```
            The encapsulation boundary following the last body part is a
            distinguished  delimiter that indicates that no further body
            parts will follow.  Such a delimiter  is  identical  to  the
            previous  delimiters,  with the addition of two more hyphens
            at the end of the line:
          
                 --gc0p4Jq0M2Yt08jU534c0p--
```

Please do review with care.