### PR TITLE
Use `example` value for samples when generating dataStructure

### DIFF
--- a/fixtures/features/api-elements/schema-reference.json
+++ b/fixtures/features/api-elements/schema-reference.json
@@ -181,6 +181,17 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "string",
+                            "attributes": {
+                              "samples": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string",
+                                    "content": "Hello"
+                                  }
+                                ]
+                              }
+                            },
                             "content": null
                           }
                         }

--- a/fixtures/features/api-elements/schema-reference.sourcemap.json
+++ b/fixtures/features/api-elements/schema-reference.sourcemap.json
@@ -279,6 +279,17 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "string",
+                            "attributes": {
+                              "samples": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string",
+                                    "content": "Hello"
+                                  }
+                                ]
+                              }
+                            },
                             "content": null
                           }
                         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Swagger example files for testing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
See https://github.com/apiaryio/fury-adapter-swagger/pull/140