### PR TITLE
chore: Release 2.12.0

### DIFF
--- a/fixtures/features/api-elements/schema-reference.json
+++ b/fixtures/features/api-elements/schema-reference.json
@@ -282,7 +282,7 @@
                               "content": "application/json"
                             }
                           },
-                          "content": "{\n  \"id\": 123,\n  \"name\": \"Item name\"\n}"
+                          "content": "{\n  \"id\": 456,\n  \"name\": \"Item name\"\n}"
                         },
                         {
                           "element": "asset",

--- a/fixtures/features/api-elements/schema-reference.sourcemap.json
+++ b/fixtures/features/api-elements/schema-reference.sourcemap.json
@@ -430,7 +430,7 @@
                               "content": "application/json"
                             }
                           },
-                          "content": "{\n  \"id\": 123,\n  \"name\": \"Item name\"\n}"
+                          "content": "{\n  \"id\": 456,\n  \"name\": \"Item name\"\n}"
                         },
                         {
                           "element": "asset",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Swagger example files for testing",
   "main": "index.js",
   "scripts": {
@@ -13,6 +13,6 @@
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT",
   "dependencies": {
-    "glob": "^6.0.1"
+    "glob": "^7.1.2"
   }
 }


### PR DESCRIPTION
Had to update the fixtures to be correct with json-schema-faker@0.5.0-rc13. Checked the generated bodies and yes, the new versions should be correct.