### PR TITLE
fix: Extensions are supported on the root level of the API spec

### DIFF
--- a/fixtures/features/api-elements/extensions.json
+++ b/fixtures/features/api-elements/extensions.json
@@ -46,6 +46,32 @@
           }
         },
         {
+          "element": "extension",
+          "meta": {
+            "links": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "link",
+                  "attributes": {
+                    "relation": {
+                      "element": "string",
+                      "content": "profile"
+                    },
+                    "href": {
+                      "element": "string",
+                      "content": "https://help.apiary.io/profiles/api-elements/vendor-extensions/"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "content": {
+            "x-root-extension": true
+          }
+        },
+        {
           "element": "resource",
           "attributes": {
             "href": {

--- a/fixtures/features/api-elements/extensions.sourcemap.json
+++ b/fixtures/features/api-elements/extensions.sourcemap.json
@@ -71,6 +71,32 @@
           }
         },
         {
+          "element": "extension",
+          "meta": {
+            "links": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "link",
+                  "attributes": {
+                    "relation": {
+                      "element": "string",
+                      "content": "profile"
+                    },
+                    "href": {
+                      "element": "string",
+                      "content": "https://help.apiary.io/profiles/api-elements/vendor-extensions/"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "content": {
+            "x-root-extension": true
+          }
+        },
+        {
           "element": "resource",
           "attributes": {
             "href": {

--- a/fixtures/features/swagger/extensions.yaml
+++ b/fixtures/features/swagger/extensions.yaml
@@ -3,7 +3,7 @@ info:
   title: Extensions
   version: '1.0'
   x-info-extension: true
-x-ignored: true
+x-root-extension: true
 paths:
   x-paths-extension: true
   '/test/{id}':


### PR DESCRIPTION
fix: Extensions are supported on the root level of [the API spec](https://swagger.io/docs/specification/2-0/swagger-extensions/)

This request is related to another [fury-adapter-swagger request](https://github.com/apiaryio/fury-adapter-swagger/pull/177), where there is still ongoing discussion on how consumers will be able to distinguish root extensions from info and paths extensions. This request will likely change again, based on the result of that discussion.