### PR TITLE
Place example values as the element content

### DIFF
--- a/fixtures/features/api-elements/body-schema-example.json
+++ b/fixtures/features/api-elements/body-schema-example.json
@@ -274,44 +274,34 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "object",
-                            "attributes": {
-                              "samples": {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "object",
-                                    "content": [
-                                      {
-                                        "element": "member",
-                                        "content": {
-                                          "key": {
-                                            "element": "string",
-                                            "content": "id"
-                                          },
-                                          "value": {
-                                            "element": "number",
-                                            "content": 123
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "element": "member",
-                                        "content": {
-                                          "key": {
-                                            "element": "string",
-                                            "content": "name"
-                                          },
-                                          "value": {
-                                            "element": "string",
-                                            "content": "Resource 1"
-                                          }
-                                        }
-                                      }
-                                    ]
+                            "content": [
+                              {
+                                "element": "member",
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "id"
+                                  },
+                                  "value": {
+                                    "element": "number",
+                                    "content": 123
                                   }
-                                ]
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "content": "Resource 1"
+                                  }
+                                }
                               }
-                            }
+                            ]
                           }
                         }
                       ]

--- a/fixtures/features/api-elements/body-schema-example.sourcemap.json
+++ b/fixtures/features/api-elements/body-schema-example.sourcemap.json
@@ -497,44 +497,34 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "object",
-                            "attributes": {
-                              "samples": {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "object",
-                                    "content": [
-                                      {
-                                        "element": "member",
-                                        "content": {
-                                          "key": {
-                                            "element": "string",
-                                            "content": "id"
-                                          },
-                                          "value": {
-                                            "element": "number",
-                                            "content": 123
-                                          }
-                                        }
-                                      },
-                                      {
-                                        "element": "member",
-                                        "content": {
-                                          "key": {
-                                            "element": "string",
-                                            "content": "name"
-                                          },
-                                          "value": {
-                                            "element": "string",
-                                            "content": "Resource 1"
-                                          }
-                                        }
-                                      }
-                                    ]
+                            "content": [
+                              {
+                                "element": "member",
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "id"
+                                  },
+                                  "value": {
+                                    "element": "number",
+                                    "content": 123
                                   }
-                                ]
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "content": "Resource 1"
+                                  }
+                                }
                               }
-                            }
+                            ]
                           }
                         }
                       ]

--- a/fixtures/features/api-elements/schema-reference.json
+++ b/fixtures/features/api-elements/schema-reference.json
@@ -178,18 +178,7 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "string",
-                            "attributes": {
-                              "samples": {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "string",
-                                    "content": "Hello"
-                                  }
-                                ]
-                              }
-                            },
-                            "content": null
+                            "content": "Hello"
                           }
                         }
                       ]

--- a/fixtures/features/api-elements/schema-reference.sourcemap.json
+++ b/fixtures/features/api-elements/schema-reference.sourcemap.json
@@ -276,18 +276,7 @@
                           "element": "dataStructure",
                           "content": {
                             "element": "string",
-                            "attributes": {
-                              "samples": {
-                                "element": "array",
-                                "content": [
-                                  {
-                                    "element": "string",
-                                    "content": "Hello"
-                                  }
-                                ]
-                              }
-                            },
-                            "content": null
+                            "content": "Hello"
                           }
                         }
                       ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-zoo",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Swagger example files for testing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The example value of a Swagger 2 Schema Object will now become the content of the element providing the following rules are met:

- There isn't already a content, for example. An array with defined items, OR an object with defined properties.

- The example value matches the type of the element.